### PR TITLE
set scope for unit-testing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,13 @@
 		    <groupId>junit</groupId>
 		    <artifactId>junit</artifactId>
 		    <version>${junit.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>${mockito.version}</version>
+			<scope>test</scope>
 		</dependency>
 				
 		


### PR DESCRIPTION
Fixing issue #1 Mockito and JUnit dependencies conflicting when project imported as a dependency